### PR TITLE
Add index pages.

### DIFF
--- a/CPlusPlus/index.html
+++ b/CPlusPlus/index.html
@@ -1,0 +1,5 @@
+<html>
+<script>
+    location.href = 'https://docs.datalogics.com/CPlusPlus/APDFL18.0.4PlusP2a'
+</script>
+</html>

--- a/CPlusPlus/index.html
+++ b/CPlusPlus/index.html
@@ -1,5 +1,5 @@
 <html>
 <script>
-    location.href = 'https://docs.datalogics.com/CPlusPlus/APDFL18.0.4PlusP2a'
+    location.href = 'APDFL18.0.4PlusP2a'
 </script>
 </html>

--- a/DotNet/index.html
+++ b/DotNet/index.html
@@ -1,0 +1,5 @@
+<html>
+<script>
+    location.href = 'https://docs.datalogics.com/DotNet/APDFL18.0.4PlusP2a/Overview/index.html'
+</script>
+</html>

--- a/DotNet/index.html
+++ b/DotNet/index.html
@@ -1,5 +1,5 @@
 <html>
 <script>
-    location.href = 'https://docs.datalogics.com/DotNet/APDFL18.0.4PlusP2a/Overview/index.html'
+    location.href = 'APDFL18.0.4PlusP2a/Overview/index.html'
 </script>
 </html>

--- a/DotNetFramework/index.html
+++ b/DotNetFramework/index.html
@@ -1,5 +1,5 @@
 <html>
 <script>
-    location.href = 'https://docs.datalogics.com/DotNetFramework/APDFL18.0.4PlusP2a/Overview/index.html'
+    location.href = 'APDFL18.0.4PlusP2a/Overview/index.html'
 </script>
 </html>

--- a/DotNetFramework/index.html
+++ b/DotNetFramework/index.html
@@ -1,0 +1,5 @@
+<html>
+<script>
+    location.href = 'https://docs.datalogics.com/DotNetFramework/APDFL18.0.4PlusP2a/Overview/index.html'
+</script>
+</html>

--- a/Java/index.html
+++ b/Java/index.html
@@ -1,0 +1,5 @@
+<html>
+<script>
+    location.href = 'https://docs.datalogics.com/Java/APDFL18.0.4PlusP2a/Overview/index.html'
+</script>
+</html>

--- a/Java/index.html
+++ b/Java/index.html
@@ -1,5 +1,5 @@
 <html>
 <script>
-    location.href = 'https://docs.datalogics.com/Java/APDFL18.0.4PlusP2a/Overview/index.html'
+    location.href = 'APDFL18.0.4PlusP2a/Overview/index.html'
 </script>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<body>
+<div>
+<h1>APDFL Documentation</h1>
+  <ul>
+    <li><h3><a href="CPlusPlus/index.html">C++</a></h3></li>
+    <li><h3><a href="DotNet/index.html">.NET</a></h3></li>
+    <li><h3><a href="DotNetFramework/index.html">.NET Framework</a></h3></li>
+    <li><h3><a href="Java/index.html">Java</a></h3></li>
+  </ul>
+</div>
+
+<table align="center">
+  <tr>
+    <td>
+        <a href="http://www.datalogics.com/" style="text-align:center">Datalogics</a>
+    </td>
+  </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
Index pages point to current release so we can just refer to the index page and not have to worry about updating links outside of this repository (e.g. documentation, website).

We'd only have to update the index content.

--
Also, add top-level basic index page to avoid errors that indicate we have misconfigured GitHub pages.  (This doesn't need any real styling.)