### PR TITLE
Update to the Release_Notes.html

### DIFF
--- a/apdfl18/Release_Notes.html
+++ b/apdfl18/Release_Notes.html
@@ -23,6 +23,27 @@
 <article id="page-8849" class="post-8849 page type-page status-publish hentry category-adobe-pdf-library">
    
 	<div class="entry-content"><p>This page lists updates, fixes, changes and enhancements made to the Adobe PDF Library v18 provided by Datalogics.</p>
+<p><strong>APDFL v18.0.4PlusP2b</strong> (August 2, 2023)</p>
+<p>New Features:</p>
+<ul type="disc">
+<li>Updates open source PNG (libPNG) library to version 1.6.40.</li>
+<li>Updated the open source tiff library to version 4.5.1.</li>
+<li>With this release, the Java and .NET Interfaces version has been increased to 18.0.4.22.</li>
+<li>With this release, the Nuget package version has been increased to 18.22.0.</li>
+<li>With this release, the Maven package version has been increased to 18.22.0.</li>
+</ul>
+<p>Problem Corrections:</p>
+<ul type="disc">
+<li>SF#45726 - Improves the usability of ASFileSysDisplayStringFromPath() when using the in-memory file system to support longer paths.</li>
+<li>SF#45758 - Corrects an issue where retrieving the Style information from Extracted Text could be incorrect in some cases.</li>
+<li>SF#45768 - Corrects an issue where the ListInks() method of the Document class of .NET or Java, could throw an exception when encountering a Spot Colorant with an incorrectly specified Name.</li>
+<li>SF#45777 - Improves support for PDF/A Parts 2 and 3 compliance with the addition of Level A options.</li>
+<li>SF#45787 – Corrects an issue where the function PDDocColorConvertPageEx() wouldn't return true to indicate a conversion failed as expected.</li>
+<li>SF#45805 – Corrects an issue where an image could disappear from the content on the page after being Optimized when a /Decode array was mishandled.</li>
+<li>SF#45811 – Improves office conversion library to now only required to be distributed if you intend to use PDF to Office functionality.</li>
+<li>SF#45826 – Adds a new method GetOutputPreviewImage() to the Page class of the .NET and Java interfaces.</li>
+</ul>
+<p>&nbsp;</p>
 <p><strong>APDFL v18.0.4PlusP2a</strong> (July 5, 2023)</p>
 <p>New Features:</p>
 <ul type="disc">


### PR DESCRIPTION
SUPP update to the Release_Notes.html (website) 
Date "August 2, 2023" is simply a place holder. It will have to be edited to the exact date when the release goes public. 