### PR TITLE
Clean up the PDF Converter Acknowledgements page by linking

### DIFF
--- a/PDFConverter/Acknowledgements.html
+++ b/PDFConverter/Acknowledgements.html
@@ -19,8 +19,8 @@
 <h1>Adobe PDF Converter Software Acknowledgements</h1>                                
 <div>
   <ul>
-  <li>libbase64</li>
-  <li>Dependencies of APDFL 18</li>
+  <li><a href="https://github.com/aklomp/base64">libbase64</a></li>
+  <li><a href="../apdfl18/CPlusPlus/Acknowledgements.html">Dependencies of APDFL 18</a></li>
   </ul>
 </body>
 </html>


### PR DESCRIPTION
Clean up the PDF Converter Acknowledgements page by linking to the APDFL page, and the project for base64.