### PR TITLE
update to the PDFConverter3.2P1e Release_Notes.html

### DIFF
--- a/PDFConverter/Release_Notes.html
+++ b/PDFConverter/Release_Notes.html
@@ -36,14 +36,30 @@
                     <h1>Release Notes, Adobe PDF Converter</h1>             
             
     <div class="entry-content"><p><strong>Please note that the Adobe PDF Converter was formerly known as Adobe Normalizer.</strong></p>
+<p><strong>PDF Converter v3.2PlusP1e</strong> (December 13, 2023)</p>
+<p>New Features:</p>
+<ul type="disc">
+<li>Adds a sample postscript "sample.ps" to the release package</li>
+</ul>
+<p>Problem Corrections:</p>
+<ul type="disc">
+<li>SF#45485 – Corrects an issue which occurs when input, job options, or other files used by democonverter are in directories with names containing Unicode characters</li>
+<li>SF#45604 – Corrects an issue in which the 'relaxDSCSetup parameter was not allowing blank lines in the Header comment section</li>
+<li>SF#45867 – Corrects an issue in which the "file" PostScript command contains a character in octal notation</li>
+<li>SF#45901 – Corrects a issue in which the PreserveHalftoneInfo setting wasn't respected in the converted PDF</li>
+<li>SF#45905 – Corrects multiple build analysis warnings in the democonverter command line program source</li>
+<li>SF#45927 – Corrects multiple memory-leaks in the demomain.c source file</li>
+<li>SF#45950 – Corrects an issue in which conversion of a Postscript file could fail unexpectedly because of an internal error</li>
+</ul>
+<p>&nbsp;</p>
 <p><strong>PDF Converter v3.2PlusP1c</strong> (September 15, 2023)</p>
 <p>Problem Corrections:</p>
 <ul type="disc">
-<li>SF#45486 – Corrects an issue where PDF Converter crashes on Japanese OS machine, when the username is in Japanese language, and using the API.</li>
-<li>SF#45831 – Corrects an issue where democonverter could crash in some cases when a subfolder's name length was greater than or equal to 9.</li>
-<li>SF#45848 – Corrects an issue where PDF Converter was writing to memory that does not belong to it.</li>
-<li>SF#45876 – Removes fpdfconversionsdk_c_win64.dll from distribution.</li>
-<li>SF#45898 – Corrects an issue with the cleanup of memory during PDFConverter termination.</li>
+<li>SF#45486 – Corrects an issue where PDF Converter crashes on Japanese OS machine, when the username is in Japanese language, and using the API</li>
+<li>SF#45831 – Corrects an issue where democonverter could crash in some cases when a subfolder's name length was greater than or equal to 9</li>
+<li>SF#45848 – Corrects an issue where PDF Converter was writing to memory that does not belong to it</li>
+<li>SF#45876 – Removes fpdfconversionsdk_c_win64.dll from distribution</li>
+<li>SF#45898 – Corrects an issue with the cleanup of memory during PDFConverter termination</li>
 </ul>
 <p>&nbsp;</p>
 <p><strong>PDF Converter v3.2PlusP1b</strong> (July 24, 2023)</p>


### PR DESCRIPTION
PDFConverter3.2P1e release notes.html update
slight edit to PDFConverter3.2P1c release notes in that the periods were all removed from the case descriptions