### PR TITLE
Add info on where PDF2IMG NuGet package doc is in reference guide

### DIFF
--- a/PDF2IMG/index.html
+++ b/PDF2IMG/index.html
@@ -20,7 +20,7 @@
  <h2>PDF2IMG</h2>
  <p>A command-line utility and API that converts PDF files to a variety of image formats, including PNG, JPG, TIFF, BMP, and more. The product is built upon the Adobe PDF Library and uses Adobe technology for unrivaled color management during the PDF conversion process. While PDF2IMG can be run with as few as two command line arguments, many other optional command line arguments are provided so that you can create custom output. PDF2IMG is available on both Windows and Linux platforms, 32 and 64 bit.</p>
  <br>
- <p>PDF2IMG's .NET interface is now available as an x64 Windows NuGet package. Please see the section marked <b>Appendix: API Calls, .NET Interface </b> in the API reference guide for more information on how to use our PDF2IMG NuGet package.
+ <p>PDF2IMG's .NET interface is now available as an <a href=https://www.nuget.org/packages/PDF2IMG.LM.NET#readme-body-tab>x64 Windows NuGet package</a>. Please see the section marked <b>Appendix: API Calls, .NET Interface </b> in the API reference guide for more information on how to use our PDF2IMG NuGet package.
 
 </p>
 <ul>

--- a/PDF2IMG/index.html
+++ b/PDF2IMG/index.html
@@ -20,7 +20,9 @@
  <h2>PDF2IMG</h2>
  <p>A command-line utility and API that converts PDF files to a variety of image formats, including PNG, JPG, TIFF, BMP, and more. The product is built upon the Adobe PDF Library and uses Adobe technology for unrivaled color management during the PDF conversion process. While PDF2IMG can be run with as few as two command line arguments, many other optional command line arguments are provided so that you can create custom output. PDF2IMG is available on both Windows and Linux platforms, 32 and 64 bit.</p>
  <br>
- <p>PDF2IMG's .NET interface is now available as an x64 Windows NuGet package.</p>
+ <p>PDF2IMG's .NET interface is now available as an x64 Windows NuGet package. Please see the section marked <b>Appendix: API Calls, .NET Interface </b> in the API reference guide for more information on how to use our PDF2IMG NuGet package.
+
+</p>
 <ul>
 <li><h3><a href="Release_Notes.html">Release Notes</a> </h3></li>
 <li><h3><a href="PDF2IMG.pdf">Documentation and API Reference</a></h3></li>


### PR DESCRIPTION
Let's be more descriptive on where to find the PDF2IMG documentation for the .NET interface used by the NuGet package.