### PR TITLE
Second Update to the v18.0.4P2x Release_Notes.html

### DIFF
--- a/apdfl18/Release_Notes.html
+++ b/apdfl18/Release_Notes.html
@@ -27,7 +27,6 @@
 <p><strong>APDFL v18.0.4PlusP2x</strong> (June 03, 2024)</p>
 <p>New Features:</p>
 <ul type="disc">
-<li>Forms Extension add-on now available for DLE Windows x64 and Linux x86_64.</li>
 <li>With this release, the Nuget package version has been increased to 18.36.0.</li>
 <li>With this release, the Maven package version has been increased to 18.36.0.</li>
 </ul>


### PR DESCRIPTION
Removed line "Forms Extension add-on now available for DLE Windows x64 and Linux x86_64."
Second update to the release_notes.html