### PR TITLE
[APDFL-5630] Update C++ Documentation to reflect Windows ARM64 support

### DIFF
--- a/FormsExtension/index.html
+++ b/FormsExtension/index.html
@@ -16,7 +16,7 @@
    </script>
 <body>
 <h1>Adobe PDF Forms Extension Documentation</h1>
-  <div><p>Datalogics offers the Forms Extension, a software module that allows applications built using the Adobe PDF Library to work with PDF AcroForm and XFA forms documents. The extension is available for separate purchase. With the integration with APDFL18, support for Linux x86_64 and arm64 was added on to the previously supported Windows x64 systems.</p>
+  <div><p>Datalogics offers the Forms Extension, a software module that allows applications built using the Adobe PDF Library to work with PDF AcroForm and XFA forms documents. The extension is available for separate purchase. With the integration with APDFL18, support for Linux x86_64 and Linux arm64 was added on to the previously supported Windows x64 systems.</p>
 <h3>What you get when you buy Forms Extension</h3>
 <ul>
 <li>A supplement for working with PDF forms documents that seamlessly integrates into the Adobe PDF Library</li>

--- a/FormsExtension/index.html
+++ b/FormsExtension/index.html
@@ -16,7 +16,9 @@
    </script>
 <body>
 <h1>Adobe PDF Forms Extension Documentation</h1>
-  <div><p>Datalogics offers the Forms Extension, a software module that allows applications built using the Adobe PDF Library to work with PDF AcroForm and XFA forms documents. The extension is available for separate purchase. With the integration with APDFL18, support for Linux x86_64 and Linux arm64 was added on to the previously supported Windows x64 systems.</p>
+  <div><p>Datalogics offers Forms Extension, an extension module that allows the Adobe PDF Library to work with PDF AcroForm and XFA forms documents.
+    <br>The supported platforms are Windows x64, Linux x86_64, and Linux arm64. The extension is available as an add-on purchase to the standard Adobe PDF Library <a href="https://www.datalogics.com/pdf-form-functions">here</a>.
+  </p>
 <h3>What you get when you buy Forms Extension</h3>
 <ul>
 <li>A supplement for working with PDF forms documents that seamlessly integrates into the Adobe PDF Library</li>

--- a/apdfl18/CPlusPlus/Getting_Started.html
+++ b/apdfl18/CPlusPlus/Getting_Started.html
@@ -82,7 +82,7 @@
                                 </tr>
                                 <tr>
                                     <td>Windows</td>
-                                    <td>x64, x86</td>
+                                    <td>x64, ARM64, x86</td>
                                     <td>Visual Studio 2022, 2019, or 2017</td>
                                 </tr>
                                 <tr>


### PR DESCRIPTION
Part of [APDFL-5630](https://datalogics-jira.atlassian.net/browse/APDFL-5630) Update C++ Documentation to reflect Windows ARM64 support
- Add ARM64 to Windows Platforms
- Add specification for Linux arm64 in forms extensions as Windows arm64 isnt supported yet

[APDFL-5630]: https://datalogics-jira.atlassian.net/browse/APDFL-5630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ